### PR TITLE
Feature/zone wrap mode

### DIFF
--- a/src/deluge/dsp/shaper.h
+++ b/src/deluge/dsp/shaper.h
@@ -49,7 +49,8 @@ struct TableShaperState {
 	uint8_t shapeX{0};             // Soft→Hard axis (0-127, "Knee")
 	uint16_t shapeY{0};            // Clean→Weird axis (0-1023, high-res multi-zone, "Color")
 	bool aa{false};                // Anti-aliasing enabled (default off, reserved for future use)
-	float gammaPhase{0.0f};        // Gamma phase for phi triangles (secret knob, 0 = LPF/hyst/sub disabled)
+	float gammaPhase{0.0f};        // Gamma phase for phi triangles (secret knob via Mix push+twist)
+	float shapeYPhaseOffset{0.0f}; // Per-knob phase offset for Y auto-wrap (1.0 = one full cycle)
 	float oscHarmonicWeight{0.5f}; // Oscillator harmonic content [0-1]: 0=sine, 0.5=saw, 1=square
 
 	// DSP smoothing state (stores last per-buffer target values)
@@ -123,6 +124,7 @@ struct TableShaperState {
 			storage::writeAttributeInt(writer, "tableShaperAA", 1);
 		}
 		WRITE_FLOAT(writer, gammaPhase, "tableShaperPhase", 10.0f);
+		WRITE_FLOAT(writer, shapeYPhaseOffset, "tableShaperYPhase", 10.0f);
 		// Secret params (push+twist modifiers)
 		WRITE_FIELD(writer, extrasMask, "tableShaperExtras");
 		WRITE_FLOAT(writer, oscHarmonicWeight, "tableShaperHarmonic", 100.0f);
@@ -137,6 +139,7 @@ struct TableShaperState {
 			return true;
 		}
 		READ_FLOAT(reader, tagName, gammaPhase, "tableShaperPhase", 10.0f);
+		READ_FLOAT(reader, tagName, shapeYPhaseOffset, "tableShaperYPhase", 10.0f);
 		// Secret params (push+twist modifiers)
 		READ_FIELD(reader, tagName, extrasMask, "tableShaperExtras");
 		READ_FLOAT(reader, tagName, oscHarmonicWeight, "tableShaperHarmonic", 100.0f);

--- a/src/deluge/dsp/shaper_buffer.h
+++ b/src/deluge/dsp/shaper_buffer.h
@@ -317,9 +317,10 @@ inline void shapeBufferInt32(std::span<q31_t> buffer, TableShaper& shaper, q31_t
 	int32_t threshold32_ctx = TableShaper::computeThreshold32(targetMixNorm_Q16);
 
 	// Hoist hysteresis offset - skip when intensity is 0 (phi triangle at zero)
+	// Always check regardless of gammaPhase - extras available via extrasMask
 	int32_t hystOffset = 0;
 	int32_t* hystState = nullptr;
-	if (state.prevScaledInput && gammaPhase != 0.0f) {
+	if (state.prevScaledInput) {
 		hystOffset = shaper.getHystOffset();
 		if (hystOffset != 0) {
 			hystState = state.prevScaledInput; // Only track slope when offset active
@@ -667,10 +668,11 @@ inline void shapeBufferInt32(std::span<StereoSample> buffer, TableShaper& shaper
 	int32_t threshold32_ctx = TableShaper::computeThreshold32(targetMixNorm_Q16);
 
 	// Hoist hysteresis offset - skip when intensity is 0 (phi triangle at zero)
+	// Always check regardless of gammaPhase - extras available via extrasMask
 	int32_t hystOffset = 0;
 	int32_t* hystStateL = nullptr;
 	int32_t* hystStateR = nullptr;
-	if (prevScaledInputL && prevScaledInputR && gammaPhase != 0.0f) {
+	if (prevScaledInputL && prevScaledInputR) {
 		hystOffset = shaper.getHystOffset();
 		if (hystOffset != 0) {
 			hystStateL = prevScaledInputL; // Only track slope when offset active

--- a/src/deluge/dsp/table_shaper.h
+++ b/src/deluge/dsp/table_shaper.h
@@ -1127,10 +1127,10 @@ struct TableShaperXYMapper {
 		float asymBase = static_cast<float>(static_cast<double>(yNorm) * phi::kPhi100 * asymFreqMult * periodScale);
 		p.asymmetry = 0.3f + triangleSimpleUnipolar(phi::wrapPhase(asymBase + ph100), kPhaseWidth) * 0.4f;
 
-		// Deadzone modifier: completely disabled at gammaPhase=0, oscillates as secret knob increases
-		// dzEnable gates the entire deadzone feature off when phase offset is zero
+		// Deadzone modifier: oscillates as Y/phase increases
+		// Always enabled - extras are gated by extrasMask (user-controlled via push+twist X)
 		constexpr float kDeadzoneDuty = 0.2f;
-		float dzEnable = (gammaPhase != 0.0f) ? 1.0f : 0.0f;
+		constexpr float dzEnable = 1.0f;
 		float dzWidthBase = static_cast<float>(static_cast<double>(yNorm) * phi::kPhiN050 * freqMult * periodScale);
 		p.deadzoneWidth = dzEnable * triangleSimpleUnipolar(phi::wrapPhase(dzWidthBase + phDzWidth), kDeadzoneDuty);
 
@@ -1206,8 +1206,8 @@ struct TableShaperXYMapper {
 		// - saw (0.5) → 70% duty (moderate)
 		// - square (1.0) → 100% duty (always active - reliable detection)
 		// φ^1.75 frequency (uncorrelated with others)
-		// Enable for gammaPhase > 0 OR high harmonic content (square waves always)
-		float slewEnable = (gammaPhase != 0.0f || oscHarmonicWeight >= 0.8f) ? 1.0f : 0.0f;
+		// Always enabled - LPF/integrator gated by extrasMask (user-controlled via push+twist X)
+		constexpr float slewEnable = 1.0f;
 		float slewDuty = std::min(1.0f, oscHarmonicWeight + 0.2f); // Range [0.2, 1.0]
 		float phSlew = phi::wrapPhase(ph * phi::kPhi175);
 		float slewBase = static_cast<float>(static_cast<double>(yNorm) * phi::kPhi175 * freqMult * periodScale);

--- a/src/deluge/gui/menu_item/stutter/scatter_zone.h
+++ b/src/deluge/gui/menu_item/stutter/scatter_zone.h
@@ -102,6 +102,15 @@ public:
 		}
 	}
 
+	// Auto-wrap support: uses per-knob zoneAPhaseOffset
+	[[nodiscard]] bool supportsAutoWrap() const override { return true; }
+	[[nodiscard]] float getPhaseOffset() const override {
+		return soundEditor.currentModControllable->stutterConfig.zoneAPhaseOffset;
+	}
+	void setPhaseOffset(float offset) override {
+		soundEditor.currentModControllable->stutterConfig.zoneAPhaseOffset = offset;
+	}
+
 	void selectEncoderAction(int32_t offset) override {
 		if (Buttons::isButtonPressed(hid::button::SELECT_ENC)) {
 			// Secret menu: adjust zoneAPhaseOffset
@@ -116,37 +125,8 @@ public:
 			suppressNotification_ = true;
 		}
 		else {
-			// Auto-wrap mode: wraps at boundaries and auto-adjusts gamma
-			int32_t scaledOffset = velocity_.getScaledOffset(offset);
-			int32_t newValue = this->getValue() + scaledOffset;
-			auto& sc = soundEditor.currentModControllable->stutterConfig;
-
-			if (newValue > kScatterResolution) {
-				// Wrap past max: go to start and increment gamma
-				this->setValue(newValue - kScatterResolution);
-				sc.gammaPhase += 1.0f;
-			}
-			else if (newValue < 0) {
-				// Wrap past min: go to end and decrement gamma (floor at 0)
-				if (sc.gammaPhase >= 1.0f) {
-					this->setValue(newValue + kScatterResolution);
-					sc.gammaPhase -= 1.0f;
-				}
-				else {
-					// At gamma=0, clamp at min (can't go negative)
-					this->setValue(0);
-				}
-			}
-			else {
-				this->setValue(newValue);
-			}
-			this->writeCurrentValue();
-			if (display->haveOLED()) {
-				renderUIsForOled();
-			}
-			else {
-				this->drawValue();
-			}
+			// Use base class auto-wrap (uses zoneAPhaseOffset via virtual methods)
+			ZoneBasedDualParam::selectEncoderAction(offset);
 		}
 	}
 
@@ -268,6 +248,15 @@ public:
 		}
 	}
 
+	// Auto-wrap support: uses per-knob zoneBPhaseOffset
+	[[nodiscard]] bool supportsAutoWrap() const override { return true; }
+	[[nodiscard]] float getPhaseOffset() const override {
+		return soundEditor.currentModControllable->stutterConfig.zoneBPhaseOffset;
+	}
+	void setPhaseOffset(float offset) override {
+		soundEditor.currentModControllable->stutterConfig.zoneBPhaseOffset = offset;
+	}
+
 	void selectEncoderAction(int32_t offset) override {
 		if (Buttons::isButtonPressed(hid::button::SELECT_ENC)) {
 			// Secret menu: adjust zoneBPhaseOffset
@@ -282,37 +271,8 @@ public:
 			suppressNotification_ = true;
 		}
 		else {
-			// Auto-wrap mode: wraps at boundaries and auto-adjusts gamma
-			int32_t scaledOffset = velocity_.getScaledOffset(offset);
-			int32_t newValue = this->getValue() + scaledOffset;
-			auto& sc = soundEditor.currentModControllable->stutterConfig;
-
-			if (newValue > kScatterResolution) {
-				// Wrap past max: go to start and increment gamma
-				this->setValue(newValue - kScatterResolution);
-				sc.gammaPhase += 1.0f;
-			}
-			else if (newValue < 0) {
-				// Wrap past min: go to end and decrement gamma (floor at 0)
-				if (sc.gammaPhase >= 1.0f) {
-					this->setValue(newValue + kScatterResolution);
-					sc.gammaPhase -= 1.0f;
-				}
-				else {
-					// At gamma=0, clamp at min (can't go negative)
-					this->setValue(0);
-				}
-			}
-			else {
-				this->setValue(newValue);
-			}
-			this->writeCurrentValue();
-			if (display->haveOLED()) {
-				renderUIsForOled();
-			}
-			else {
-				this->drawValue();
-			}
+			// Use base class auto-wrap (uses zoneBPhaseOffset via virtual methods)
+			ZoneBasedDualParam::selectEncoderAction(offset);
 		}
 	}
 

--- a/src/deluge/gui/menu_item/stutter/scatter_zone.h
+++ b/src/deluge/gui/menu_item/stutter/scatter_zone.h
@@ -116,7 +116,37 @@ public:
 			suppressNotification_ = true;
 		}
 		else {
-			ZoneBasedDualParam::selectEncoderAction(offset);
+			// Auto-wrap mode: wraps at boundaries and auto-adjusts gamma
+			int32_t scaledOffset = velocity_.getScaledOffset(offset);
+			int32_t newValue = this->getValue() + scaledOffset;
+			auto& sc = soundEditor.currentModControllable->stutterConfig;
+
+			if (newValue > kScatterResolution) {
+				// Wrap past max: go to start and increment gamma
+				this->setValue(newValue - kScatterResolution);
+				sc.gammaPhase += 1.0f;
+			}
+			else if (newValue < 0) {
+				// Wrap past min: go to end and decrement gamma (floor at 0)
+				if (sc.gammaPhase >= 1.0f) {
+					this->setValue(newValue + kScatterResolution);
+					sc.gammaPhase -= 1.0f;
+				}
+				else {
+					// At gamma=0, clamp at min (can't go negative)
+					this->setValue(0);
+				}
+			}
+			else {
+				this->setValue(newValue);
+			}
+			this->writeCurrentValue();
+			if (display->haveOLED()) {
+				renderUIsForOled();
+			}
+			else {
+				this->drawValue();
+			}
 		}
 	}
 
@@ -252,7 +282,37 @@ public:
 			suppressNotification_ = true;
 		}
 		else {
-			ZoneBasedDualParam::selectEncoderAction(offset);
+			// Auto-wrap mode: wraps at boundaries and auto-adjusts gamma
+			int32_t scaledOffset = velocity_.getScaledOffset(offset);
+			int32_t newValue = this->getValue() + scaledOffset;
+			auto& sc = soundEditor.currentModControllable->stutterConfig;
+
+			if (newValue > kScatterResolution) {
+				// Wrap past max: go to start and increment gamma
+				this->setValue(newValue - kScatterResolution);
+				sc.gammaPhase += 1.0f;
+			}
+			else if (newValue < 0) {
+				// Wrap past min: go to end and decrement gamma (floor at 0)
+				if (sc.gammaPhase >= 1.0f) {
+					this->setValue(newValue + kScatterResolution);
+					sc.gammaPhase -= 1.0f;
+				}
+				else {
+					// At gamma=0, clamp at min (can't go negative)
+					this->setValue(0);
+				}
+			}
+			else {
+				this->setValue(newValue);
+			}
+			this->writeCurrentValue();
+			if (display->haveOLED()) {
+				renderUIsForOled();
+			}
+			else {
+				this->drawValue();
+			}
 		}
 	}
 


### PR DESCRIPTION
makes it so when you hit the end of an infinite zone, it "just keeps going" instead of needing the user to know about secret phase offset and gamma.