### PR TITLE
feat: wire disperser, automod, sine shaper, table shaper in GlobalEffectable

### DIFF
--- a/src/deluge/dsp/automodulator.hpp
+++ b/src/deluge/dsp/automodulator.hpp
@@ -145,7 +145,8 @@ constexpr phi::PhiTriConfig kCombMixTriangle = {phi::kPhi350, 0.85f, 0.00f, fals
 constexpr phi::PhiTriConfig kSvfFeedbackTriangle = {phi::kPhi175, 0.25f, 0.1078f, true};
 
 /// Phi triangle config for tremolo depth derived from flavor
-constexpr phi::PhiTriConfig kTremoloDepthTriangle = {phi::kPhi275, 0.7f, 0.00f, false}; // No tremolo at zone 0
+constexpr phi::PhiTriConfig kTremoloDepthTriangle = {phi::kPhi275, 0.0f, 0.00f,
+                                                     false}; // Disabled: band mixing provides AM
 
 /// Phi triangle config for tremolo phase offset derived from flavor
 constexpr phi::PhiTriConfig kTremoloPhaseOffsetTriangle = {phi::kPhi225, 0.6f, 0.75f, false};
@@ -502,6 +503,9 @@ struct AutomodDspState {
 	// Allpass interpolator state for comb delay line (reduces aliasing on fast modulation)
 	q31_t allpassStateL{0};
 	q31_t allpassStateR{0};
+
+	// Previous buffer's filter base cutoff (for per-sample interpolation to avoid clicks)
+	q31_t prevFilterBase{0};
 };
 
 /// Automodulator parameters and DSP state (stored per-Sound)

--- a/src/deluge/gui/menu_item/stutter/density.h
+++ b/src/deluge/gui/menu_item/stutter/density.h
@@ -150,7 +150,7 @@ public:
 		return deluge::modulation::params::Kind::PATCHED;
 	}
 
-	bool usesAffectEntire() override { return true; }
+	bool usesAffectEntire() override { return false; }
 
 	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuValue; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }

--- a/src/deluge/gui/menu_item/stutter/quantized.h
+++ b/src/deluge/gui/menu_item/stutter/quantized.h
@@ -186,7 +186,7 @@ public:
 		return deluge::modulation::params::Kind::PATCHED;
 	}
 
-	bool usesAffectEntire() override { return true; }
+	bool usesAffectEntire() override { return false; }
 
 	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuValue; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }

--- a/src/deluge/gui/menu_item/stutter/scatter_macro.h
+++ b/src/deluge/gui/menu_item/stutter/scatter_macro.h
@@ -173,7 +173,7 @@ public:
 		return deluge::modulation::params::Kind::PATCHED;
 	}
 
-	bool usesAffectEntire() override { return true; }
+	bool usesAffectEntire() override { return false; }
 
 	// === Encoder action with secret menu ===
 

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -124,6 +124,7 @@ public:
 
 	// Sine shaper parameters and DSP state (struct defined in dsp/sine_shaper.hpp)
 	deluge::dsp::SineTableShaperParams sineShaper;
+	deluge::dsp::SineShaperVoiceState sineShaperGlobalState; // Per-clip state for GlobalEffectable path
 
 	// Automodulator (auto-wah/filter/tremolo/comb)
 	deluge::dsp::AutomodulatorParams automod;


### PR DESCRIPTION
## Summary
- **perf(automod):** Tremolo early-out and debug cleanup, buffer-rate LFO evaluation with comb spring smoothing (6032→4364 cycles)
- **fix(stutter):** pWrite grain boundary fades and disable affect-entire for scatter params
- **feat:** Wire disperser, automod, sine shaper, and table shaper DSP into `GlobalEffectableForClip::renderOutput()` so all four effects process audio on kits and audio clips (not just synth patches)

## Details
All four effects already had full dual-param support (unpatched param IDs, `getUnpatchedFallback()` mappings, menu items with CC learning and automation), but their DSP was only called from `Sound::render()`. This PR adds the missing DSP calls in the GlobalEffectable render path:

- **Sine shaper** — reads `UNPATCHED_SINE_SHAPER_DRIVE/HARMONIC/TWIST`, adds `sineShaperGlobalState` to `ModControllableAudio` for per-clip state
- **Table shaper** — reads `UNPATCHED_TABLE_SHAPER_DRIVE/MIX`
- **Disperser** — reads `UNPATCHED_DISPERSER_TOPO/TWIST`
- **Automodulator** — reads `UNPATCHED_AUTOMOD_DEPTH/FREQ/MANUAL`

## Test plan
- [ ] Build with `./dbt build`
- [ ] Enable automod on a kit — verify DSP processes and gold knob automation works
- [ ] Enable disperser on an audio clip — verify effect is audible
- [ ] Enable sine shaper on a kit — verify drive/harmonic/twist params affect audio
- [ ] Enable table shaper on a kit — verify drive/mix params affect audio
- [ ] Verify all four effects still work correctly on synth patches (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)