### PR TITLE
fix: zone scrolling bugs — backward wrap, disperser auto-wrap, floor/popup

### DIFF
--- a/src/deluge/dsp/util.hpp
+++ b/src/deluge/dsp/util.hpp
@@ -97,8 +97,8 @@ inline void foldBuffer(q31_t* startSample, q31_t* endSample, q31_t foldLevel) {
 /// @param duty Active portion 0.0-1.0 (default 1.0 = full triangle, no deadzone)
 /// @return Output 0.0 to 1.0
 inline float triangleSimpleUnipolar(float phase, float duty = 1.0f) {
-	// Fast floor via int32_t truncation (valid for non-negative phase)
-	phase = phase - static_cast<float>(static_cast<int32_t>(phase));
+	// Wrap to [0,1) — floorf handles negative phases correctly (truncation does not)
+	phase = phase - floorf(phase);
 	float halfDuty = duty * 0.5f;
 	float invHalfDuty = 2.0f / duty; // One division instead of two
 
@@ -116,8 +116,8 @@ inline float triangleSimpleUnipolar(float phase, float duty = 1.0f) {
 /// @param duty Active portion 0.0-1.0 (default 1.0 = full triangle, no deadzone)
 /// @return Output -1.0 to +1.0
 inline float triangleFloat(float phase, float duty = 1.0f) {
-	// Fast floor via int32_t truncation (valid for non-negative phase)
-	phase = phase - static_cast<float>(static_cast<int32_t>(phase));
+	// Wrap to [0,1) — floorf handles negative phases correctly (truncation does not)
+	phase = phase - floorf(phase);
 	float quarterDuty = duty * 0.25f;
 	float halfDuty = duty * 0.5f;
 

--- a/src/deluge/gui/menu_item/audio_compressor/multiband.h
+++ b/src/deluge/gui/menu_item/audio_compressor/multiband.h
@@ -550,7 +550,7 @@ private:
 	static void cacheCoordDisplay(float phaseOffset, int32_t value) {
 		// Format: "P:Z" where P=phaseOffset (int), Z=zone index (0-7)
 		// 128 encoder clicks = 1 zone (1024 / 8 = 128)
-		int32_t p = static_cast<int32_t>(phaseOffset * 10.0f);
+		int32_t p = static_cast<int32_t>(std::floor(phaseOffset * 10.0f));
 		int32_t z = value >> 7; // 0-1023 → 0-7 (zone index)
 		snprintf(coordBuffer_, sizeof(coordBuffer_), "%d:%d", p, z);
 	}

--- a/src/deluge/gui/menu_item/fx/automodulator.h
+++ b/src/deluge/gui/menu_item/fx/automodulator.h
@@ -681,7 +681,7 @@ public:
 			float& phase = soundEditor.currentModControllable->automod.typePhaseOffset;
 			phase = std::max(0.0f, phase + static_cast<float>(offset) * 1.0f);
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "T:%d", static_cast<int32_t>(phase));
+			snprintf(buffer, sizeof(buffer), "T:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -735,7 +735,7 @@ private:
 	// Shared coordinate display buffer
 	static inline char coordBuffer_[12] = {};
 	static void cacheCoordDisplay(float phaseOffset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phaseOffset);
+		int32_t p = static_cast<int32_t>(std::floor(phaseOffset));
 		int32_t z = value >> 7; // 0-1023 → 0-7 (zone index)
 		snprintf(coordBuffer_, sizeof(coordBuffer_), "%d:%d", p, z);
 	}
@@ -802,7 +802,7 @@ public:
 			float& phase = soundEditor.currentModControllable->automod.flavorPhaseOffset;
 			phase = std::max(0.0f, phase + static_cast<float>(offset) * 1.0f);
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "F:%d", static_cast<int32_t>(phase));
+			snprintf(buffer, sizeof(buffer), "F:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -856,7 +856,7 @@ private:
 	// Shared coordinate display buffer
 	static inline char coordBuffer_[12] = {};
 	static void cacheCoordDisplay(float phaseOffset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phaseOffset);
+		int32_t p = static_cast<int32_t>(std::floor(phaseOffset));
 		int32_t z = value >> 7; // 0-1023 → 0-7 (zone index)
 		snprintf(coordBuffer_, sizeof(coordBuffer_), "%d:%d", p, z);
 	}
@@ -913,7 +913,7 @@ public:
 			float& phase = soundEditor.currentModControllable->automod.modPhaseOffset;
 			phase = std::max(0.0f, phase + static_cast<float>(velocity_.getScaledOffset(offset)) * 1.0f);
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "M:%d", static_cast<int32_t>(phase));
+			snprintf(buffer, sizeof(buffer), "M:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -1001,7 +1001,7 @@ private:
 	// Shared coordinate display buffer
 	static inline char coordBuffer_[12] = {};
 	static void cacheCoordDisplay(float phaseOffset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phaseOffset);
+		int32_t p = static_cast<int32_t>(std::floor(phaseOffset));
 		int32_t z = value >> 7; // 0-1023 → 0-7 (zone index)
 		snprintf(coordBuffer_, sizeof(coordBuffer_), "%d:%d", p, z);
 	}

--- a/src/deluge/gui/menu_item/fx/shaper.h
+++ b/src/deluge/gui/menu_item/fx/shaper.h
@@ -289,7 +289,7 @@ private:
 	static void cacheTwistNum(float gammaPhase, int32_t value) {
 		// Format: "P:Y" where P=gammaPhase (int), Y=zone index (0-7)
 		// 128 encoder clicks = 1 zone, so Y increments once per zone traversal
-		int32_t p = static_cast<int32_t>(gammaPhase);
+		int32_t p = static_cast<int32_t>(std::floor(gammaPhase));
 		int32_t y = value >> 7; // 0-1023 → 0-7 (zone index)
 		snprintf(twistBuffer_, sizeof(twistBuffer_), "%d:%d", p, y);
 	}

--- a/src/deluge/gui/menu_item/fx/sine_shaper.h
+++ b/src/deluge/gui/menu_item/fx/sine_shaper.h
@@ -257,7 +257,7 @@ public:
 			float& phase = soundEditor.currentModControllable->sineShaper.twistPhaseOffset;
 			phase = std::max(0.0f, phase + static_cast<float>(velocity_.getScaledOffset(offset)) * 1.0f);
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "T:%d", static_cast<int32_t>(phase));
+			snprintf(buffer, sizeof(buffer), "T:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -314,7 +314,7 @@ private:
 
 	static inline char coord_buffer_[12] = {};
 	static void cacheCoordDisplay(float phase_offset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phase_offset);
+		int32_t p = static_cast<int32_t>(std::floor(phase_offset));
 		int32_t z = value >> 7; // 0-1023 → 0-7 (zone index)
 		snprintf(coord_buffer_, sizeof(coord_buffer_), "%d:%d", p, z);
 	}

--- a/src/deluge/gui/menu_item/osc/phi_morph_zone.h
+++ b/src/deluge/gui/menu_item/osc/phi_morph_zone.h
@@ -106,7 +106,7 @@ public:
 			float& phase = (zoneId_ == 0) ? source.phiMorphPhaseOffsetA : source.phiMorphPhaseOffsetB;
 			phase = std::max(0.0f, phase + static_cast<float>(velocity_.getScaledOffset(offset)) * 1.0f);
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "P:%d", static_cast<int32_t>(phase));
+			snprintf(buffer, sizeof(buffer), "P:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -166,7 +166,7 @@ private:
 
 	static inline char coordBuffer_[12] = {};
 	static void cacheCoordDisplay(float phaseOffset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phaseOffset);
+		int32_t p = static_cast<int32_t>(std::floor(phaseOffset));
 		int32_t z = value >> 7; // 0-1023 -> 0-7 (zone index)
 		snprintf(coordBuffer_, sizeof(coordBuffer_), "%d:%d", p, z);
 	}

--- a/src/deluge/gui/menu_item/stutter/scatter_zone.h
+++ b/src/deluge/gui/menu_item/stutter/scatter_zone.h
@@ -117,9 +117,9 @@ public:
 			Buttons::selectButtonPressUsedUp = true;
 			float& phase = soundEditor.currentModControllable->stutterConfig.zoneAPhaseOffset;
 			phase = std::max(0.0f, phase + static_cast<float>(velocity_.getScaledOffset(offset)) * 0.1f);
-			// Show current value on display
+			// Show effective value on display (includes gamma contribution)
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "offset:%d", static_cast<int32_t>(phase * 10.0f));
+			snprintf(buffer, sizeof(buffer), "offset:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -174,7 +174,7 @@ private:
 
 	static inline char coord_buffer_[12] = {};
 	static void cacheCoordDisplay(float phase_offset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phase_offset);
+		int32_t p = static_cast<int32_t>(std::floor(phase_offset));
 		int32_t z = value >> 7; // 0-1023 → 0-7 (zone index)
 		snprintf(coord_buffer_, sizeof(coord_buffer_), "%d:%d", p, z);
 	}
@@ -263,9 +263,9 @@ public:
 			Buttons::selectButtonPressUsedUp = true;
 			float& phase = soundEditor.currentModControllable->stutterConfig.zoneBPhaseOffset;
 			phase = std::max(0.0f, phase + static_cast<float>(velocity_.getScaledOffset(offset)) * 0.1f);
-			// Show current value on display
+			// Show effective value on display (includes gamma contribution)
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "offset:%d", static_cast<int32_t>(phase * 10.0f));
+			snprintf(buffer, sizeof(buffer), "offset:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -319,7 +319,7 @@ private:
 
 	static inline char coord_buffer_[12] = {};
 	static void cacheCoordDisplay(float phase_offset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phase_offset);
+		int32_t p = static_cast<int32_t>(std::floor(phase_offset));
 		int32_t z = value >> 7;
 		snprintf(coord_buffer_, sizeof(coord_buffer_), "%d:%d", p, z);
 	}
@@ -396,9 +396,9 @@ public:
 			Buttons::selectButtonPressUsedUp = true;
 			float& phase = soundEditor.currentModControllable->stutterConfig.macroConfigPhaseOffset;
 			phase = std::max(0.0f, phase + static_cast<float>(velocity_.getScaledOffset(offset)) * 0.1f);
-			// Show current value on display
+			// Show effective value on display (includes gamma contribution)
 			char buffer[16];
-			snprintf(buffer, sizeof(buffer), "offset:%d", static_cast<int32_t>(phase * 10.0f));
+			snprintf(buffer, sizeof(buffer), "offset:%d", static_cast<int32_t>(std::floor(effectivePhaseOffset())));
 			display->displayPopup(buffer);
 			renderUIsForOled();
 			suppressNotification_ = true;
@@ -453,7 +453,7 @@ private:
 
 	static inline char coord_buffer_[12] = {};
 	static void cacheCoordDisplay(float phase_offset, int32_t value) {
-		int32_t p = static_cast<int32_t>(phase_offset);
+		int32_t p = static_cast<int32_t>(std::floor(phase_offset));
 		int32_t z = value >> 7;
 		snprintf(coord_buffer_, sizeof(coord_buffer_), "%d:%d", p, z);
 	}

--- a/src/deluge/gui/menu_item/zone_based.h
+++ b/src/deluge/gui/menu_item/zone_based.h
@@ -151,15 +151,9 @@ public:
 				setPhaseOffset(phaseOffset + 1.0f);
 			}
 			else if (newValue < 0) {
-				// Wrap past min: go to end and decrement phase offset (floor at 0)
-				if (phaseOffset >= 1.0f) {
-					this->setValue(newValue + RESOLUTION);
-					setPhaseOffset(phaseOffset - 1.0f);
-				}
-				else {
-					// At phaseOffset=0, clamp at min (can't go negative)
-					this->setValue(0);
-				}
+				// Wrap past min: go to end and decrement phase offset
+				this->setValue(newValue + RESOLUTION);
+				setPhaseOffset(phaseOffset - 1.0f);
 			}
 			else {
 				this->setValue(newValue);
@@ -345,15 +339,9 @@ public:
 				setPhaseOffset(phaseOffset + 1.0f);
 			}
 			else if (newValue < 0) {
-				// Wrap past min: go to end and decrement phase offset (floor at 0)
-				if (phaseOffset >= 1.0f) {
-					this->setValue(newValue + RESOLUTION);
-					setPhaseOffset(phaseOffset - 1.0f);
-				}
-				else {
-					// At phaseOffset=0, clamp at min (can't go negative)
-					this->setValue(0);
-				}
+				// Wrap past min: go to end and decrement phase offset
+				this->setValue(newValue + RESOLUTION);
+				setPhaseOffset(phaseOffset - 1.0f);
 			}
 			else {
 				this->setValue(newValue);


### PR DESCRIPTION
## Summary
- Remove backward scroll guard in `zone_based.h` — allows infinite bidirectional scrolling when gamma > 0 (phaseOffset can go negative)
- Add auto-wrap support to DisperserTopo and DisperserTwist (were missing `supportsAutoWrap`/`getPhaseOffset`/`setPhaseOffset` overrides)
- Fix `triangleSimpleUnipolar`/`triangleFloat` in `util.hpp` to use `floorf()` instead of `int32_t` truncation (broken for negative phases)
- Fix `cacheCoordDisplay` truncation across all zone menu items to use `std::floor()` for correct negative phase handling
- Fix push+twist popups to show effective phase offset (including gamma contribution) instead of raw per-knob offset, matching coordinate display

## Test plan
- [ ] Verify backward scrolling works on any zone knob when gamma > 0 (e.g. push+twist wave index to increase gamma, then scroll zone knob left past 0)
- [ ] Verify disperser Topo and Twist zone knobs now wrap infinitely like other zone knobs
- [ ] Verify push+twist popup values match the P:Z coordinate display (especially with gamma > 0)
- [ ] Verify no display glitches with negative phase offsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)