### PR TITLE
fix: add missing serialization for all new effect params

### DIFF
--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -532,6 +532,12 @@ void ModControllableAudio::writeAttributesToFile(Serializer& writer) {
 	shaper.writeToFile(writer);
 	// Disperser state
 	disperser.writeToFile(writer);
+	// Sine shaper state
+	sineShaper.writeToFile(writer);
+	// Automodulator state
+	automod.writeToFile(writer);
+	// Multiband compressor state
+	multibandCompressor.writeToFile(writer);
 }
 
 void ModControllableAudio::writeTagsToFile(Serializer& writer) {
@@ -657,6 +663,81 @@ void ModControllableAudio::writeParamAttributesToFile(Serializer& writer, ParamM
 	unpatchedParams->writeParamAsAttribute(writer, "compressorThreshold", params::UNPATCHED_COMPRESSOR_THRESHOLD,
 	                                       writeAutomation, false, valuesForOverride);
 
+	// Multiband compressor params
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorCharacter", params::UNPATCHED_MB_COMPRESSOR_CHARACTER,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorLowCrossover",
+	                                       params::UNPATCHED_MB_COMPRESSOR_LOW_CROSSOVER, writeAutomation, true,
+	                                       valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorHighCrossover",
+	                                       params::UNPATCHED_MB_COMPRESSOR_HIGH_CROSSOVER, writeAutomation, true,
+	                                       valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorThreshold", params::UNPATCHED_MB_COMPRESSOR_THRESHOLD,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorRatio", params::UNPATCHED_MB_COMPRESSOR_RATIO,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorAttack", params::UNPATCHED_MB_COMPRESSOR_ATTACK,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorRelease", params::UNPATCHED_MB_COMPRESSOR_RELEASE,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorSkew", params::UNPATCHED_MB_COMPRESSOR_SKEW,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorLowLevel", params::UNPATCHED_MB_COMPRESSOR_LOW_LEVEL,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorMidLevel", params::UNPATCHED_MB_COMPRESSOR_MID_LEVEL,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorHighLevel", params::UNPATCHED_MB_COMPRESSOR_HIGH_LEVEL,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorOutputGain",
+	                                       params::UNPATCHED_MB_COMPRESSOR_OUTPUT_GAIN, writeAutomation, true,
+	                                       valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorVibe", params::UNPATCHED_MB_COMPRESSOR_VIBE,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "mbCompressorBlend", params::UNPATCHED_MB_COMPRESSOR_BLEND,
+	                                       writeAutomation, true, valuesForOverride);
+
+	// Sine shaper params (clip/global context)
+	unpatchedParams->writeParamAsAttribute(writer, "clipSineShaperDrive", params::UNPATCHED_SINE_SHAPER_DRIVE,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "clipSineShaperHarmonic", params::UNPATCHED_SINE_SHAPER_HARMONIC,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "clipSineShaperSymmetry", params::UNPATCHED_SINE_SHAPER_TWIST,
+	                                       writeAutomation, true, valuesForOverride);
+
+	// Table shaper params (clip/global context)
+	unpatchedParams->writeParamAsAttribute(writer, "clipTableShaperDrive", params::UNPATCHED_TABLE_SHAPER_DRIVE,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "clipTableShaperMix", params::UNPATCHED_TABLE_SHAPER_MIX,
+	                                       writeAutomation, true, valuesForOverride);
+
+	// Disperser params
+	unpatchedParams->writeParamAsAttribute(writer, "disperserTopo", params::UNPATCHED_DISPERSER_TOPO, writeAutomation,
+	                                       true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "disperserTwist", params::UNPATCHED_DISPERSER_TWIST, writeAutomation,
+	                                       true, valuesForOverride);
+
+	// Automodulator params
+	unpatchedParams->writeParamAsAttribute(writer, "clipAutomodMacro", params::UNPATCHED_AUTOMOD_DEPTH, writeAutomation,
+	                                       true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "clipAutomodFreq", params::UNPATCHED_AUTOMOD_FREQ, writeAutomation,
+	                                       true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "clipAutomodManual", params::UNPATCHED_AUTOMOD_MANUAL,
+	                                       writeAutomation, true, valuesForOverride);
+
+	// Scatter params
+	unpatchedParams->writeParamAsAttribute(writer, "scatterZoneA", params::UNPATCHED_SCATTER_ZONE_A, writeAutomation,
+	                                       true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "scatterZoneB", params::UNPATCHED_SCATTER_ZONE_B, writeAutomation,
+	                                       true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "scatterDepth", params::UNPATCHED_SCATTER_MACRO_CONFIG,
+	                                       writeAutomation, true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "scatterMacro", params::UNPATCHED_SCATTER_MACRO, writeAutomation,
+	                                       true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "scatterPWrite", params::UNPATCHED_SCATTER_PWRITE, writeAutomation,
+	                                       true, valuesForOverride);
+	unpatchedParams->writeParamAsAttribute(writer, "scatterDensity", params::UNPATCHED_SCATTER_DENSITY, writeAutomation,
+	                                       true, valuesForOverride);
+
 	unpatchedParams->writeParamAsAttribute(writer, "arpeggiatorGate", params::UNPATCHED_ARP_GATE, writeAutomation);
 	unpatchedParams->writeParamAsAttribute(writer, "noteProbability", params::UNPATCHED_NOTE_PROBABILITY,
 	                                       writeAutomation);
@@ -767,6 +848,168 @@ bool ModControllableAudio::readParamTagFromFile(Deserializer& reader, char const
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_COMPRESSOR_THRESHOLD,
 		                           readAutomationUpToPos);
 		reader.exitTag("compressorThreshold");
+	}
+
+	// Multiband compressor params
+	else if (!strcmp(tagName, "mbCompressorCharacter")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_CHARACTER,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorCharacter");
+	}
+	else if (!strcmp(tagName, "mbCompressorLowCrossover")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_LOW_CROSSOVER,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorLowCrossover");
+	}
+	else if (!strcmp(tagName, "mbCompressorHighCrossover")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_HIGH_CROSSOVER,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorHighCrossover");
+	}
+	else if (!strcmp(tagName, "mbCompressorThreshold")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_THRESHOLD,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorThreshold");
+	}
+	else if (!strcmp(tagName, "mbCompressorRatio")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_RATIO,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorRatio");
+	}
+	else if (!strcmp(tagName, "mbCompressorAttack")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_ATTACK,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorAttack");
+	}
+	else if (!strcmp(tagName, "mbCompressorRelease")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_RELEASE,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorRelease");
+	}
+	else if (!strcmp(tagName, "mbCompressorSkew")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_SKEW,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorSkew");
+	}
+	else if (!strcmp(tagName, "mbCompressorLowLevel")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_LOW_LEVEL,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorLowLevel");
+	}
+	else if (!strcmp(tagName, "mbCompressorMidLevel")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_MID_LEVEL,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorMidLevel");
+	}
+	else if (!strcmp(tagName, "mbCompressorHighLevel")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_HIGH_LEVEL,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorHighLevel");
+	}
+	else if (!strcmp(tagName, "mbCompressorOutputGain")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_OUTPUT_GAIN,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorOutputGain");
+	}
+	else if (!strcmp(tagName, "mbCompressorVibe")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_VIBE,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorVibe");
+	}
+	else if (!strcmp(tagName, "mbCompressorBlend")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MB_COMPRESSOR_BLEND,
+		                           readAutomationUpToPos);
+		reader.exitTag("mbCompressorBlend");
+	}
+
+	// Sine shaper params (clip/global context)
+	else if (!strcmp(tagName, "clipSineShaperDrive")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SINE_SHAPER_DRIVE,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipSineShaperDrive");
+	}
+	else if (!strcmp(tagName, "clipSineShaperHarmonic")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SINE_SHAPER_HARMONIC,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipSineShaperHarmonic");
+	}
+	else if (!strcmp(tagName, "clipSineShaperSymmetry")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SINE_SHAPER_TWIST,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipSineShaperSymmetry");
+	}
+
+	// Table shaper params (clip/global context)
+	else if (!strcmp(tagName, "clipTableShaperDrive")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_TABLE_SHAPER_DRIVE,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipTableShaperDrive");
+	}
+	else if (!strcmp(tagName, "clipTableShaperMix")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_TABLE_SHAPER_MIX,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipTableShaperMix");
+	}
+
+	// Disperser params
+	else if (!strcmp(tagName, "disperserTopo")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_DISPERSER_TOPO,
+		                           readAutomationUpToPos);
+		reader.exitTag("disperserTopo");
+	}
+	else if (!strcmp(tagName, "disperserTwist")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_DISPERSER_TWIST,
+		                           readAutomationUpToPos);
+		reader.exitTag("disperserTwist");
+	}
+
+	// Automodulator params
+	else if (!strcmp(tagName, "clipAutomodMacro")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_AUTOMOD_DEPTH,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipAutomodMacro");
+	}
+	else if (!strcmp(tagName, "clipAutomodFreq")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_AUTOMOD_FREQ,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipAutomodFreq");
+	}
+	else if (!strcmp(tagName, "clipAutomodManual")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_AUTOMOD_MANUAL,
+		                           readAutomationUpToPos);
+		reader.exitTag("clipAutomodManual");
+	}
+
+	// Scatter params
+	else if (!strcmp(tagName, "scatterZoneA")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SCATTER_ZONE_A,
+		                           readAutomationUpToPos);
+		reader.exitTag("scatterZoneA");
+	}
+	else if (!strcmp(tagName, "scatterZoneB")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SCATTER_ZONE_B,
+		                           readAutomationUpToPos);
+		reader.exitTag("scatterZoneB");
+	}
+	else if (!strcmp(tagName, "scatterDepth")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SCATTER_MACRO_CONFIG,
+		                           readAutomationUpToPos);
+		reader.exitTag("scatterDepth");
+	}
+	else if (!strcmp(tagName, "scatterMacro")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SCATTER_MACRO,
+		                           readAutomationUpToPos);
+		reader.exitTag("scatterMacro");
+	}
+	else if (!strcmp(tagName, "scatterPWrite")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SCATTER_PWRITE,
+		                           readAutomationUpToPos);
+		reader.exitTag("scatterPWrite");
+	}
+	else if (!strcmp(tagName, "scatterDensity")) {
+		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SCATTER_DENSITY,
+		                           readAutomationUpToPos);
+		reader.exitTag("scatterDensity");
 	}
 
 	// Arpeggiator stuff
@@ -901,6 +1144,21 @@ Error ModControllableAudio::readTagFromFile(Deserializer& reader, char const* ta
 
 	// Disperser state
 	else if (disperser.readTag(reader, tagName)) {
+		// Reading handled internally
+	}
+
+	// Sine shaper state
+	else if (sineShaper.readTag(reader, tagName)) {
+		// Reading handled internally
+	}
+
+	// Automodulator state
+	else if (automod.readTag(reader, tagName)) {
+		// Reading handled internally
+	}
+
+	// Multiband compressor state
+	else if (multibandCompressor.readTag(reader, tagName)) {
 		// Reading handled internally
 	}
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3468,6 +3468,26 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 			patch->setEngineMode(reader.readTagOrAttributeValueInt());
 			reader.exitTag("dx7enginemode");
 		}
+		else if (!strcmp(tagName, "phiMorphZoneA")) {
+			source->phiMorphZoneA = reader.readTagOrAttributeValueInt();
+			reader.exitTag("phiMorphZoneA");
+		}
+		else if (!strcmp(tagName, "phiMorphZoneB")) {
+			source->phiMorphZoneB = reader.readTagOrAttributeValueInt();
+			reader.exitTag("phiMorphZoneB");
+		}
+		else if (!strcmp(tagName, "phiMorphPhaseA")) {
+			source->phiMorphPhaseOffsetA = static_cast<float>(reader.readTagOrAttributeValueInt()) / 10.0f;
+			reader.exitTag("phiMorphPhaseA");
+		}
+		else if (!strcmp(tagName, "phiMorphPhaseB")) {
+			source->phiMorphPhaseOffsetB = static_cast<float>(reader.readTagOrAttributeValueInt()) / 10.0f;
+			reader.exitTag("phiMorphPhaseB");
+		}
+		else if (!strcmp(tagName, "phiMorphGamma")) {
+			source->phiMorphGamma = static_cast<float>(reader.readTagOrAttributeValueInt()) / 10.0f;
+			reader.exitTag("phiMorphGamma");
+		}
 		/*
 		else if (!strcmp(tagName, "sampleSync")) {
 		    source->sampleSync = stringToBool(reader.readTagContents());
@@ -3817,6 +3837,20 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 			goto justCloseTag;
 		}
 		else {
+			// PHI_MORPH: persist zone knobs, phase offsets, and gamma
+			if (source->oscType == OscType::PHI_MORPH) {
+				writer.writeAttribute("phiMorphZoneA", source->phiMorphZoneA);
+				writer.writeAttribute("phiMorphZoneB", source->phiMorphZoneB);
+				if (source->phiMorphPhaseOffsetA != 0.0f) {
+					writer.writeAttribute("phiMorphPhaseA", static_cast<int32_t>(source->phiMorphPhaseOffsetA * 10.0f));
+				}
+				if (source->phiMorphPhaseOffsetB != 0.0f) {
+					writer.writeAttribute("phiMorphPhaseB", static_cast<int32_t>(source->phiMorphPhaseOffsetB * 10.0f));
+				}
+				if (source->phiMorphGamma != 0.0f) {
+					writer.writeAttribute("phiMorphGamma", static_cast<int32_t>(source->phiMorphGamma * 10.0f));
+				}
+			}
 justCloseTag:
 			writer.closeTag();
 		}
@@ -4102,6 +4136,81 @@ bool Sound::readParamTagFromFile(Deserializer& reader, char const* tagName, Para
 		paramManager->getPatchCableSet()->readPatchCablesFromFile(reader, readAutomationUpToPos);
 		reader.exitTag("patchCables");
 	}
+
+	// Shaper params (patched, Sound context)
+	else if (!strcmp(tagName, "tableShaperDrive")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_TABLE_SHAPER_DRIVE, readAutomationUpToPos);
+		reader.exitTag("tableShaperDrive");
+	}
+	else if (!strcmp(tagName, "tableShaperMix")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_TABLE_SHAPER_MIX, readAutomationUpToPos);
+		reader.exitTag("tableShaperMix");
+	}
+	else if (!strcmp(tagName, "sineShaperDrive")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_SINE_SHAPER_DRIVE, readAutomationUpToPos);
+		reader.exitTag("sineShaperDrive");
+	}
+	else if (!strcmp(tagName, "sineShaperTwist")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_SINE_SHAPER_TWIST, readAutomationUpToPos);
+		reader.exitTag("sineShaperTwist");
+	}
+	else if (!strcmp(tagName, "patchedSineShaperHarmonic")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_SINE_SHAPER_HARMONIC,
+		                         readAutomationUpToPos);
+		reader.exitTag("patchedSineShaperHarmonic");
+	}
+
+	// Disperser params (patched, Sound context)
+	else if (!strcmp(tagName, "globalDisperserTopo")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_DISPERSER_TOPO, readAutomationUpToPos);
+		reader.exitTag("globalDisperserTopo");
+	}
+	else if (!strcmp(tagName, "globalDisperserTwist")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_DISPERSER_TWIST, readAutomationUpToPos);
+		reader.exitTag("globalDisperserTwist");
+	}
+
+	// Automodulator params (patched, Sound context)
+	else if (!strcmp(tagName, "globalAutomodMacro")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_AUTOMOD_DEPTH, readAutomationUpToPos);
+		reader.exitTag("globalAutomodMacro");
+	}
+	else if (!strcmp(tagName, "globalAutomodFreq")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_AUTOMOD_FREQ, readAutomationUpToPos);
+		reader.exitTag("globalAutomodFreq");
+	}
+	else if (!strcmp(tagName, "globalAutomodManual")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_AUTOMOD_MANUAL, readAutomationUpToPos);
+		reader.exitTag("globalAutomodManual");
+	}
+
+	// Scatter params (patched, Sound context)
+	else if (!strcmp(tagName, "globalScatterZoneA")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_SCATTER_ZONE_A, readAutomationUpToPos);
+		reader.exitTag("globalScatterZoneA");
+	}
+	else if (!strcmp(tagName, "globalScatterZoneB")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_SCATTER_ZONE_B, readAutomationUpToPos);
+		reader.exitTag("globalScatterZoneB");
+	}
+	else if (!strcmp(tagName, "globalScatterDepth")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_SCATTER_MACRO_CONFIG,
+		                         readAutomationUpToPos);
+		reader.exitTag("globalScatterDepth");
+	}
+	else if (!strcmp(tagName, "globalScatterMacro")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_SCATTER_MACRO, readAutomationUpToPos);
+		reader.exitTag("globalScatterMacro");
+	}
+	else if (!strcmp(tagName, "globalScatterPWrite")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_SCATTER_PWRITE, readAutomationUpToPos);
+		reader.exitTag("globalScatterPWrite");
+	}
+	else if (!strcmp(tagName, "globalScatterDensity")) {
+		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_SCATTER_DENSITY, readAutomationUpToPos);
+		reader.exitTag("globalScatterDensity");
+	}
+
 	else if (ModControllableAudio::readParamTagFromFile(reader, tagName, paramManager, readAutomationUpToPos)) {}
 
 	else {
@@ -4182,6 +4291,46 @@ void Sound::writeParamsToFile(Serializer& writer, ParamManager* paramManager, bo
 	patchedParams->writeParamAsAttribute(writer, "hpfMorph", params::LOCAL_HPF_MORPH, writeAutomation);
 
 	patchedParams->writeParamAsAttribute(writer, "waveFold", params::LOCAL_FOLD, writeAutomation);
+
+	// Shaper params (patched, Sound context)
+	patchedParams->writeParamAsAttribute(writer, "tableShaperDrive", params::LOCAL_TABLE_SHAPER_DRIVE, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "tableShaperMix", params::LOCAL_TABLE_SHAPER_MIX, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "sineShaperDrive", params::LOCAL_SINE_SHAPER_DRIVE, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "sineShaperTwist", params::LOCAL_SINE_SHAPER_TWIST, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "patchedSineShaperHarmonic", params::LOCAL_SINE_SHAPER_HARMONIC,
+	                                     writeAutomation, true);
+
+	// Disperser params (patched, Sound context)
+	patchedParams->writeParamAsAttribute(writer, "globalDisperserTopo", params::GLOBAL_DISPERSER_TOPO, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "globalDisperserTwist", params::GLOBAL_DISPERSER_TWIST,
+	                                     writeAutomation, true);
+
+	// Automodulator params (patched, Sound context)
+	patchedParams->writeParamAsAttribute(writer, "globalAutomodMacro", params::GLOBAL_AUTOMOD_DEPTH, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "globalAutomodFreq", params::GLOBAL_AUTOMOD_FREQ, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "globalAutomodManual", params::GLOBAL_AUTOMOD_MANUAL, writeAutomation,
+	                                     true);
+
+	// Scatter params (patched, Sound context)
+	patchedParams->writeParamAsAttribute(writer, "globalScatterZoneA", params::GLOBAL_SCATTER_ZONE_A, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "globalScatterZoneB", params::GLOBAL_SCATTER_ZONE_B, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "globalScatterDepth", params::GLOBAL_SCATTER_MACRO_CONFIG,
+	                                     writeAutomation, true);
+	patchedParams->writeParamAsAttribute(writer, "globalScatterMacro", params::GLOBAL_SCATTER_MACRO, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "globalScatterPWrite", params::GLOBAL_SCATTER_PWRITE, writeAutomation,
+	                                     true);
+	patchedParams->writeParamAsAttribute(writer, "globalScatterDensity", params::GLOBAL_SCATTER_DENSITY,
+	                                     writeAutomation, true);
 
 	writer.writeOpeningTagEnd();
 


### PR DESCRIPTION
## Summary
- Hooks up multiband compressor, sine shaper, and automodulator struct-level writeToFile/readTag in ModControllableAudio (previously defined but never called)
- Creates automodulator serialization from scratch (10 fields: mix, rate, rateSynced, lfoMode, type, flavor, mod, typePhaseOffset, flavorPhaseOffset, modPhaseOffset, gammaPhase)
- Adds phi morph oscillator source-level serialization (zoneA/B, phaseOffsetA/B, gamma) in Sound::writeSourceToFile/readSourceFromFile
- Adds 30 missing unpatched param write/read calls in ModControllableAudio (14 multiband, 3 sine shaper, 2 table shaper, 2 disperser, 3 automod, 6 scatter)
- Adds 17 missing patched param write/read calls in Sound (5 LOCAL shaper, 2 GLOBAL disperser, 3 GLOBAL automod, 7 GLOBAL scatter)

Without these, saving a project with any new effects would lose all knob positions, zone settings, and secret params on reload.

## Test plan
- [ ] Create a synth patch using multiple new effects (DOTT, disperser, sine shaper, table shaper, automodulator, scatter)
- [ ] Adjust all knobs including push+twist secret params (phase offsets, gamma)
- [ ] Save the project, reload it, and verify all effect settings are restored
- [ ] Test on a kit track (GlobalEffectable path) as well as a synth track (Sound path)
- [ ] Verify phi morph oscillator zone/phase settings persist across save/load
- [ ] Verify backwards compatibility: loading a project saved before this fix should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)