### PR TITLE
fix: prevent E411 crash on AudioClip param access

### DIFF
--- a/src/deluge/gui/menu_item/fx/automodulator.h
+++ b/src/deluge/gui/menu_item/fx/automodulator.h
@@ -89,7 +89,7 @@ constexpr int32_t kNumSyncRates = sizeof(kSyncRates) / sizeof(kSyncRates[0]);
 
 // Helpers for dual patched/unpatched automod param access (Sound vs GlobalEffectable contexts)
 inline q31_t getAutomodParamValue(params::ParamType patched, params::ParamType unpatched) {
-	if (soundEditor.currentParamManager->containsAnyMainParamCollections()) {
+	if (soundEditor.currentParamManager->hasPatchedParamSet()) {
 		return soundEditor.currentParamManager->getPatchedParamSet()->getValue(patched);
 	}
 	return soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(unpatched);
@@ -98,7 +98,7 @@ inline q31_t getAutomodParamValue(params::ParamType patched, params::ParamType u
 inline ModelStackWithAutoParam* getAutomodModelStack(void* memory, params::ParamType patched,
                                                      params::ParamType unpatched) {
 	ModelStackWithThreeMainThings* modelStack = soundEditor.getCurrentModelStack(memory);
-	if (soundEditor.currentParamManager->containsAnyMainParamCollections()) {
+	if (soundEditor.currentParamManager->hasPatchedParamSet()) {
 		return modelStack->getPatchedAutoParamFromId(patched);
 	}
 	return modelStack->getUnpatchedAutoParamFromId(unpatched);

--- a/src/deluge/gui/menu_item/fx/sine_shaper.h
+++ b/src/deluge/gui/menu_item/fx/sine_shaper.h
@@ -40,7 +40,7 @@ namespace deluge::gui::menu_item::fx {
 
 // Helpers for dual patched/unpatched param access (Sound vs GlobalEffectable contexts)
 inline q31_t getShapingParamValue(params::ParamType patched, params::ParamType unpatched) {
-	if (soundEditor.currentParamManager->containsAnyMainParamCollections()) {
+	if (soundEditor.currentParamManager->hasPatchedParamSet()) {
 		return soundEditor.currentParamManager->getPatchedParamSet()->getValue(patched);
 	}
 	return soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(unpatched);
@@ -49,7 +49,7 @@ inline q31_t getShapingParamValue(params::ParamType patched, params::ParamType u
 inline ModelStackWithAutoParam* getShapingModelStack(void* memory, params::ParamType patched,
                                                      params::ParamType unpatched) {
 	ModelStackWithThreeMainThings* modelStack = soundEditor.getCurrentModelStack(memory);
-	if (soundEditor.currentParamManager->containsAnyMainParamCollections()) {
+	if (soundEditor.currentParamManager->hasPatchedParamSet()) {
 		return modelStack->getPatchedAutoParamFromId(patched);
 	}
 	return modelStack->getUnpatchedAutoParamFromId(unpatched);

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -245,7 +245,7 @@ ModelStackWithAutoParam* ModelStackWithThreeMainThings::getUnpatchedAutoParamFro
 
 ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchedAutoParamFromId(int32_t newParamId) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+	if (paramManager && paramManager->hasPatchedParamSet()) {
 		ParamCollectionSummary* summary = paramManager->getPatchedParamSetSummary();
 
 		ModelStackWithParamId* modelStackWithParamId =
@@ -258,7 +258,7 @@ ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchedAutoParamFromI
 
 ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchCableAutoParamFromId(int32_t newParamId) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+	if (paramManager && paramManager->hasPatchedParamSet()) {
 		ParamCollectionSummary* summary = paramManager->getPatchCableSetSummary();
 
 		ModelStackWithParamId* modelStackWithParamId =


### PR DESCRIPTION
## Summary
- Fixes E411 freeze when navigating FX menus on AudioClips (e.g., automod, sine shaper params)
- Root cause: wrong guard functions (`containsAnyMainParamCollections()`, `containsAnyParamCollectionsIncludingExpression()`) return true for AudioClip's unpatched-only ParamManager, then code dereferences the null PatchedParamSet in `summaries[1]`
- Fix: replace with `hasPatchedParamSet()` which correctly returns false for AudioClips, routing to the unpatched fallback path instead

## Details
AudioClip uses `setupUnpatched()` which only populates `summaries[0]` (UnpatchedParamSet) and sets `summaries[1] = {0}` (null). The incorrect guards:
- `containsAnyMainParamCollections()` checks `expressionParamSetOffset` — returns 1 (truthy) for unpatched
- `containsAnyParamCollectionsIncludingExpression()` checks `summaries[0].paramCollection` — returns the UnpatchedParamSet pointer (truthy)

Both pass for AudioClip, but the code then calls `getPatchedParamSet()` or `getPatchedParamSetSummary()` which hits `FREEZE_WITH_ERROR("E411")` at param_manager.h:121/130.

## Files changed
- `automodulator.h` — `getAutomodParamValue()`, `getAutomodModelStack()`
- `sine_shaper.h` — `getShapingParamValue()`, `getShapingModelStack()`
- `model_stack.cpp` — `getPatchedAutoParamFromId()`, `getPatchCableAutoParamFromId()`

## Test plan
- [ ] Load an audio clip, navigate to FX menus (automod, sine shaper) — should not crash
- [ ] Verify Sound instrument FX menus still work correctly (patched path)
- [ ] Verify GlobalEffectable FX menus still work (unpatched path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)